### PR TITLE
Start using custom navbar

### DIFF
--- a/packages/pih-esm-root-config/src/applications.ts
+++ b/packages/pih-esm-root-config/src/applications.ts
@@ -1,5 +1,7 @@
 import { routePrefix, routeRegex } from "@openmrs/esm-root-config";
 
+/* We define the MFEs we want to include, each with an _activity function_
+ *   (see https://single-spa.js.org/docs/configuration/#activity-function) */
 export const applications = {
   "@openmrs/esm-login": shouldShowLogin,
   "@openmrs/esm-devtools": shouldShowDevtools,

--- a/packages/pih-esm-root-config/src/applications.ts
+++ b/packages/pih-esm-root-config/src/applications.ts
@@ -30,5 +30,5 @@ function shouldShowNavbar() {
 }
 
 function shouldShowReferralsQueue(location) {
-  location.pathname.includes("/referrals-queue");
+  return routePrefix("referrals-queue", location);
 }

--- a/packages/pih-esm-root-config/src/applications.ts
+++ b/packages/pih-esm-root-config/src/applications.ts
@@ -1,0 +1,34 @@
+import { routePrefix, routeRegex } from "@openmrs/esm-root-config";
+
+export const applications = {
+  "@openmrs/esm-login": shouldShowLogin,
+  "@openmrs/esm-devtools": shouldShowDevtools,
+  "@openmrs/esm-patient-chart": shouldShowPatientChart,
+  "@openmrs/esm-home": shouldShowHome,
+  "@pih/esm-refapp-navbar": shouldShowNavbar,
+  "@pih/esm-referrals-queue": shouldShowReferralsQueue,
+};
+
+function shouldShowLogin(location) {
+  return routePrefix("login", location);
+}
+
+function shouldShowDevtools() {
+  return localStorage.getItem("openmrs:devtools");
+}
+
+function shouldShowPatientChart(location) {
+  return routeRegex(/^patient\/.+\/chart/, location);
+}
+
+function shouldShowHome(location) {
+  return routePrefix("home", location);
+}
+
+function shouldShowNavbar() {
+  return true;
+}
+
+function shouldShowReferralsQueue(location) {
+  location.pathname.includes("/referrals-queue");
+}

--- a/packages/pih-esm-root-config/src/pih-esm-root-config.ts
+++ b/packages/pih-esm-root-config/src/pih-esm-root-config.ts
@@ -1,15 +1,14 @@
 import { start, registerApplication } from "single-spa";
-import {
-  registerAllCoreApplications,
-  promiseBeforeStart,
-} from "@openmrs/esm-root-config";
+import { promiseBeforeStart } from "@openmrs/esm-root-config";
+import { applications } from "./applications";
 
-registerAllCoreApplications();
-registerApplication(
-  "@pih/esm-referrals-queue",
-  () => System.import("@pih/esm-referrals-queue"),
-  (location) => location.pathname.includes("/referrals-queue")
-);
+Object.keys(applications).forEach((appName) => {
+  registerApplication(
+    appName,
+    () => System.import(appName),
+    applications[appName]
+  );
+});
 
 promiseBeforeStart.then(start).catch((err) => {
   console.error(`Failed to initialize i18next translations`);


### PR DESCRIPTION
This transitions us off of using the core apps. All of the former core apps are included, except [esm-primary-navigation](https://github.com/openmrs/openmrs-esm-primary-navigation). It is being replaced with [pih/esm-refapp-navbar](https://github.com/PIH/pih-esm-refapp-navbar).